### PR TITLE
Fix broken main package entry point.

### DIFF
--- a/svelte-material-icons/package.json
+++ b/svelte-material-icons/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-material-icons",
   "version": "2.0.2",
   "description": "Material Design Icons for Svelte",
-  "main": "\"\"",
+  "main": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The entry point for the package is broken causing an error when building an app that has a package that depends on svelte-material-icons in vite.  

`Failed to resolve entry for package "svelte-material-icons". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "svelte-material-icons". The package may have incorrect main/module/exports specified in its package.json.`

Usually this can be ignored but, in my team's case it is causing our storybook build to break. So I'd appreciate if this could be resolved relatively quickly.

On another note this is kind of just a stop gap fix to stop the error. The other solution I tried that would work would be to replace main with 
``` json
 "type": "module",
  "exports": {
    "./*": "./*.svelte"
  },
```

 I thought this could cause possible incompatibilities with people using cjs. However, if you like this solution better I will make a PR with that instead. 