### PR TITLE
Add description property

### DIFF
--- a/build.js
+++ b/build.js
@@ -67,6 +67,9 @@ const generateComponentSource = (file) => {
   $svg.attr("height", "{height}");
   $svg.attr("viewBox", "{viewBox}");
 
+  // add desc
+  $svg.prepend("{#if desc}<desc>{desc}</desc>{/if}");
+
   const $path = $svg.find("> path");
   
   // add fill attr

--- a/icon.d.ts
+++ b/icon.d.ts
@@ -6,4 +6,5 @@ export default class Icon extends SvelteComponentTyped<{
   height?: string | number
   color?: string
   viewBox?: string
+  desc?: string
 }> {}

--- a/template.svelte
+++ b/template.svelte
@@ -4,7 +4,7 @@
   export let height = size;
   export let color = "currentColor";
   export let viewBox = "0 0 24 24";
-  export let desc;
+  export let desc = undefined;
 </script>
 
 %svg%

--- a/template.svelte
+++ b/template.svelte
@@ -4,6 +4,7 @@
   export let height = size;
   export let color = "currentColor";
   export let viewBox = "0 0 24 24";
+  export let desc;
 </script>
 
 %svg%


### PR DESCRIPTION
The desc element is useful for making SVGs accessible with the ability to describe the purpose of the SVG with longer text than with a title, especially for functional icons (such as account or settings buttons). This change adds the optional desc property which, when filled, adds the desc element to the SVG.

Note: For easier merging, the classes have not been generated in this branch. They will have to be rebuilt after merge. Also, if the title element is added, it should be prepended after the desc element, so that the title element goes first.